### PR TITLE
Fix typo in CashflowCategoryRepository

### DIFF
--- a/site/src/Repository/CashflowCategoryRepository.php
+++ b/site/src/Repository/CashflowCategoryRepository.php
@@ -27,7 +27,7 @@ class CashflowCategoryRepository
         Assert::uuid($id);
         $object = $this->repo->find($id);
         if ($object === null) {
-            throw new DomainException('CashFloCategory not fount');
+            throw new DomainException(sprintf('CashflowCategory %s not found', $id));
         }
 
         return $object;


### PR DESCRIPTION
## Summary
- fix the exception text in `CashflowCategoryRepository`

## Testing
- `make site-test` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684a546145d08323b49894bdd9521baf