### PR TITLE
Fix cashflow report logic

### DIFF
--- a/site/src/Controller/CashflowReportController.php
+++ b/site/src/Controller/CashflowReportController.php
@@ -21,7 +21,6 @@ class CashflowReportController extends AbstractController
         $months = [];
         $report = [];
         $balances = [];
-        $categoryDirections = [];
 
         // стартовый баланс по всем счетам
         $startBalance = 0;
@@ -52,16 +51,11 @@ class CashflowReportController extends AbstractController
                 $cur = $cur->getParent();
             }
 
-            $direction = $txn->getDirection();
             $amount = $txn->getAmount();
+            $direction = $txn->getDirection();
+            $signed = $direction === 'expense' ? -$amount : $amount;
 
-            foreach ($path as $name) {
-                if (!isset($categoryDirections[$name])) {
-                    $categoryDirections[$name] = $direction;
-                }
-            }
-
-            $addToReport($report, $path, $month, $amount);
+            $addToReport($report, $path, $month, $signed);
 
             $balances[$month][$direction] = ($balances[$month][$direction] ?? 0) + $amount;
         }
@@ -100,7 +94,6 @@ class CashflowReportController extends AbstractController
             'monthly' => $monthly,
             'months' => $monthKeys,
             'rootCategories' => $rootCategories,
-            'categoryDirections' => $categoryDirections,
         ]);
     }
 }

--- a/site/templates/finance/cashflow/report_grouped.html.twig
+++ b/site/templates/finance/cashflow/report_grouped.html.twig
@@ -1,20 +1,20 @@
 {# templates/finance/cashflow/report_grouped.html.twig #}
 {% extends 'base.html.twig' %}
 {% block title %}ДДС — по месяцам (версия из ТЗ){% endblock %}
-{% macro render_node(name, node, level, months, categoryDirections) %}
-    {% set is_expense = (categoryDirections[name]|default('income')) == 'expense' %}
+{% macro render_node(name, node, level, months) %}
     <tr class="{{ level == 1 ? 'fw-bold' : '' }}">
         <td class="ps-{{ (level - 1) * 2 }}">{{ name }}</td>
         {% for month in months %}
             {% set value = node.__total[month]|default(0) %}
-            <td class="text-end {{ is_expense ? 'text-danger' : '' }}">
-                {{ is_expense and value != 0 ? '-' : '' }}{{ value|number_format(0, '.', ' ') }}
+            {% set is_negative = value < 0 %}
+            <td class="text-end {{ is_negative ? 'text-danger' : '' }}">
+                {{ is_negative ? '-' : '' }}{{ value|abs|number_format(0, '.', ' ') }}
             </td>
         {% endfor %}
     </tr>
     {% if level < 4 %}
         {% for childName, childNode in node.__children %}
-            {{ _self.render_node(childName, childNode, level + 1, months, categoryDirections) }}
+            {{ _self.render_node(childName, childNode, level + 1, months) }}
         {% endfor %}
     {% endif %}
 {% endmacro %}
@@ -50,7 +50,7 @@
                 {% for root in rootCategories %}
                     {% set name = root.name %}
                     {% if report[name] is defined %}
-                        {{ macros.render_node(name, report[name], 1, months, categoryDirections) }}
+                        {{ macros.render_node(name, report[name], 1, months) }}
                     {% endif %}
                 {% endfor %}
                 <tr class="fw-bold bg-light">


### PR DESCRIPTION
## Summary
- fix category aggregation logic in cashflow report controller
- show negative totals automatically in cashflow report template

## Testing
- `composer install --no-interaction` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a5dcaa8fc83238a5162ae397ae350