### PR TITLE
Add pagination for cashflow transactions

### DIFF
--- a/site/src/Controller/CashflowTransactionController.php
+++ b/site/src/Controller/CashflowTransactionController.php
@@ -18,11 +18,20 @@ use Symfony\Component\Routing\Attribute\Route;
 class CashflowTransactionController extends AbstractController
 {
     #[Route('/finance/cashflow', name: 'cashflow_index')]
-    public function index(CashflowTransactionRepository $repository): Response
+    public function index(Request $request, CashflowTransactionRepository $repository): Response
     {
-        $transactions = $repository->listByCompanyId($this->getUser()->getCompanies()[0]->getId());
+        $page = max(1, (int)$request->query->get('page', 1));
+        $perPage = 10;
+        $companyId = $this->getUser()->getCompanies()[0]->getId();
+
+        $transactions = $repository->paginateByCompanyId($companyId, $page, $perPage);
+        $total = $repository->countByCompanyId($companyId);
+        $pages = (int)ceil($total / $perPage);
+
         return $this->render('finance/cashflow/index.html.twig', [
-            'transactions' => $transactions
+            'transactions' => $transactions,
+            'page' => $page,
+            'pages' => $pages,
         ]);
     }
 

--- a/site/src/Repository/CashflowTransactionRepository.php
+++ b/site/src/Repository/CashflowTransactionRepository.php
@@ -27,4 +27,31 @@ class CashflowTransactionRepository
         return $this->repo->findBy(['company' => $id]);
     }
 
+    public function countByCompanyId(string $id): int
+    {
+        Assert::uuid($id);
+        return (int)$this->repo->createQueryBuilder('t')
+            ->select('count(t.id)')
+            ->andWhere('t.company = :company')
+            ->setParameter('company', $id)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    public function paginateByCompanyId(string $id, int $page, int $perPage): array
+    {
+        Assert::uuid($id);
+        Assert::greaterThanEq($page, 1);
+        Assert::greaterThanEq($perPage, 1);
+
+        $qb = $this->repo->createQueryBuilder('t')
+            ->andWhere('t.company = :company')
+            ->setParameter('company', $id)
+            ->orderBy('t.date', 'DESC')
+            ->setFirstResult(($page - 1) * $perPage)
+            ->setMaxResults($perPage);
+
+        return $qb->getQuery()->getResult();
+    }
+
 }

--- a/site/templates/finance/cashflow/index.html.twig
+++ b/site/templates/finance/cashflow/index.html.twig
@@ -23,4 +23,15 @@
         {% endfor %}
         </tbody>
     </table>
+    {% if pages > 1 %}
+        <nav>
+            <ul class="pagination">
+                {% for p in 1..pages %}
+                    <li class="page-item{% if p == page %} active{% endif %}">
+                        <a class="page-link" href="{{ path('cashflow_index', { page: p }) }}">{{ p }}</a>
+                    </li>
+                {% endfor %}
+            </ul>
+        </nav>
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- add pagination support in CashflowTransactionRepository
- paginate and sort in CashflowTransactionController
- show pagination controls in the transactions template

## Testing
- `php bin/phpunit` *(fails: `php` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a613c1f788323a2300885ba859d04