### PR TITLE
Render category tree in cashflow form

### DIFF
--- a/site/src/Entity/CashflowCategory.php
+++ b/site/src/Entity/CashflowCategory.php
@@ -122,6 +122,27 @@ class CashflowCategory
     {
         return $this->name;
     }
+
+    public function isLeaf(): bool
+    {
+        return $this->children->isEmpty();
+    }
+
+    public function getDepth(): int
+    {
+        $depth = 0;
+        $parent = $this->getParent();
+        while ($parent !== null) {
+            $depth++;
+            $parent = $parent->getParent();
+        }
+        return $depth;
+    }
+
+    public function getIndentedName(): string
+    {
+        return str_repeat('-- ', $this->getDepth()) . $this->name;
+    }
     /*public function getTransactions(): Collection
     {
         return $this->transactions;

--- a/site/src/Form/CashflowTransactionType.php
+++ b/site/src/Form/CashflowTransactionType.php
@@ -47,8 +47,17 @@ class CashflowTransactionType extends AbstractType
             ])
             ->add('category', EntityType::class, [
                 'class' => CashflowCategory::class,
-                'choice_label' => 'name',
-                'label' => 'Категория'
+                'choice_label' => fn (CashflowCategory $category) => $category->getIndentedName(),
+                'label' => 'Категория',
+                'query_builder' => function (EntityRepository $er) use ($options) {
+                    return $er->createQueryBuilder('c')
+                        ->leftJoin('c.children', 'child')
+                        ->where('c.company = :company')
+                        ->andWhere('child.id IS NULL')
+                        ->setParameter('company', $options['company'] ?? null)
+                        ->orderBy('c.sortOrder', 'ASC')
+                        ->addOrderBy('c.name', 'ASC');
+                },
             ])
             ->add('comment', Type\TextareaType::class, [ 'required' => false, 'label' => 'Комментарий' ]);
     }

--- a/site/src/Repository/CashflowCategoryRepository.php
+++ b/site/src/Repository/CashflowCategoryRepository.php
@@ -39,6 +39,20 @@ class CashflowCategoryRepository
         return $this->repo->findBy(['company' => $id]);
     }
 
+    public function listLeavesByCompanyId(string $id): array
+    {
+        Assert::uuid($id);
+        return $this->repo->createQueryBuilder('c')
+            ->leftJoin('c.children', 'child')
+            ->andWhere('c.company = :company')
+            ->andWhere('child.id IS NULL')
+            ->setParameter('company', $id)
+            ->orderBy('c.sortOrder', 'ASC')
+            ->addOrderBy('c.name', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
     public function findBy(array $criteria, array|null $orderBy = null): array
     {
         return $this->repo->findBy($criteria, $orderBy);


### PR DESCRIPTION
## Summary
- add helper methods to `CashflowCategory` for tree rendering
- add repository method to retrieve only leaf categories
- show leaf categories as indented tree when editing transactions

## Testing
- `make site-test` *(fails: `docker: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_684a627c81548323a844c19d16f01372