### PR TITLE
Fix CashflowTransaction date type

### DIFF
--- a/site/src/Entity/CashflowTransaction.php
+++ b/site/src/Entity/CashflowTransaction.php
@@ -18,7 +18,7 @@ class CashflowTransaction
     private ?string $id = null;
 
     #[ORM\Column(type: 'datetime_immutable')]
-    private \DateTimeInterface $date;
+    private \DateTimeImmutable $date;
 
     #[ORM\Column(type: 'float')]
     private float $amount;
@@ -54,8 +54,8 @@ class CashflowTransaction
 
 
     public function getId(): ?string { return $this->id; }
-    public function getDate(): \DateTimeInterface { return $this->date; }
-    public function setDate(\DateTimeInterface $date): self { $this->date = $date; return $this; }
+    public function getDate(): \DateTimeImmutable { return $this->date; }
+    public function setDate(\DateTimeImmutable $date): self { $this->date = $date; return $this; }
     public function getAmount(): float { return $this->amount; }
 
     public function getAccount(): ?CashAccount

--- a/site/src/Form/CashflowTransactionType.php
+++ b/site/src/Form/CashflowTransactionType.php
@@ -22,7 +22,11 @@ class CashflowTransactionType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('date', Type\DateType::class, [ 'widget' => 'single_text', 'label' => 'Дата' ])
+            ->add('date', Type\DateType::class, [
+                'widget' => 'single_text',
+                'label' => 'Дата',
+                'input' => 'datetime_immutable',
+            ])
             ->add('project', EntityType::class, [
                 'class' => Project::class,
                 'label' => 'Проект',


### PR DESCRIPTION
## Summary
- ensure form uses immutable date objects
- update CashflowTransaction entity to store `DateTimeImmutable`

## Testing
- `composer install --no-interaction` *(fails: command not found)*
- `bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a66a7af8c832380a33fd2979fdb98