### PR TITLE
Add project filter for cashflow report

### DIFF
--- a/site/src/Controller/CashflowReportController.php
+++ b/site/src/Controller/CashflowReportController.php
@@ -4,7 +4,9 @@ namespace App\Controller;
 
 use App\Repository\CashflowCategoryRepository;
 use App\Repository\CashflowTransactionRepository;
+use App\Repository\ProjectRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
@@ -12,11 +14,14 @@ class CashflowReportController extends AbstractController
 {
     #[Route('/finance/cashflow/report', name: 'cashflow_report')]
     public function index(
+        Request $request,
         CashflowTransactionRepository $repository,
-        CashflowCategoryRepository $categoryRepository
+        CashflowCategoryRepository $categoryRepository,
+        ProjectRepository $projectRepository,
     ): Response {
         $company = $this->getUser()->getCompanies()[0];
-        $transactions = $repository->listByCompanyId($company->getId());
+        $projectId = $request->query->get('project');
+        $transactions = $repository->listByCompanyId($company->getId(), $projectId ?: null);
 
         $months = [];
         $report = [];
@@ -84,6 +89,8 @@ class CashflowReportController extends AbstractController
             'sortOrder' => 'ASC',
         ]);
 
+        $projects = $projectRepository->listByCompanyId($company->getId());
+
 
 
 
@@ -94,6 +101,8 @@ class CashflowReportController extends AbstractController
             'monthly' => $monthly,
             'months' => $monthKeys,
             'rootCategories' => $rootCategories,
+            'projects' => $projects,
+            'selectedProject' => $projectId,
         ]);
     }
 }

--- a/site/src/Repository/CashflowTransactionRepository.php
+++ b/site/src/Repository/CashflowTransactionRepository.php
@@ -21,10 +21,21 @@ class CashflowTransactionRepository
         $this->repo = $em->getRepository(CashflowTransaction::class);
     }
 
-    public function listByCompanyId(string $id): array
+    public function listByCompanyId(string $id, ?string $projectId = null): array
     {
         Assert::uuid($id);
-        return $this->repo->findBy(['company' => $id]);
+
+        $qb = $this->repo->createQueryBuilder('t')
+            ->andWhere('t.company = :company')
+            ->setParameter('company', $id);
+
+        if ($projectId !== null) {
+            Assert::uuid($projectId);
+            $qb->andWhere('t.project = :project')
+                ->setParameter('project', $projectId);
+        }
+
+        return $qb->getQuery()->getResult();
     }
 
     public function countByCompanyId(string $id): int

--- a/site/src/Repository/ProjectRepository.php
+++ b/site/src/Repository/ProjectRepository.php
@@ -25,4 +25,13 @@ class ProjectRepository
     {
         return $this->repo->findAll();
     }
+
+    public function listByCompanyId(string $companyId): array
+    {
+        return $this->repo->findBy([
+            'company' => $companyId,
+        ], [
+            'name' => 'ASC',
+        ]);
+    }
 }

--- a/site/templates/finance/cashflow/report_grouped.html.twig
+++ b/site/templates/finance/cashflow/report_grouped.html.twig
@@ -24,6 +24,17 @@
             <h2>Отчёт ДДС (по строкам)</h2>
         </div>
 
+        <form method="get" class="row mb-3">
+            <div class="col-auto">
+                <select name="project" class="form-select" onchange="this.form.submit()">
+                    <option value="">Все проекты</option>
+                    {% for project in projects %}
+                        <option value="{{ project.id }}" {% if project.id == selectedProject %}selected{% endif %}>{{ project.name }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+        </form>
+
         <div class="table-responsive">
             <table class="table table-bordered table-striped">
                 <thead class="thead-light">


### PR DESCRIPTION
## Summary
- enable filtering cashflow report by project
- expose projects in controller
- allow repository to filter transactions by project
- list projects per company
- add dropdown on the report page

## Testing
- `php ./vendor/bin/phpunit` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684a682b9d6883238c68dd5f73bfa7d1