### PR TITLE
Add JSON API for cash flow report

### DIFF
--- a/site/src/Controller/Api/CashflowReportController.php
+++ b/site/src/Controller/Api/CashflowReportController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Controller\Api;
+
+use App\Service\CashflowReportService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Attribute\Route;
+
+class CashflowReportController extends AbstractController
+{
+    #[Route('/api/finance/cashflow/report', name: 'api_cashflow_report')]
+    public function index(Request $request, CashflowReportService $service): JsonResponse
+    {
+        $company = $this->getUser()->getCompanies()[0];
+        $projectId = $request->query->get('project');
+
+        $data = $service->build($company, $projectId ?: null);
+
+        // convert entities to simple arrays for JSON response
+        $data['rootCategories'] = array_map(static fn($c) => [
+            'id' => $c->getId(),
+            'name' => $c->getName(),
+        ], $data['rootCategories']);
+        $data['projects'] = array_map(static fn($p) => [
+            'id' => $p->getId(),
+            'name' => $p->getName(),
+        ], $data['projects']);
+
+        return new JsonResponse($data);
+    }
+}

--- a/site/src/Controller/CashflowReportController.php
+++ b/site/src/Controller/CashflowReportController.php
@@ -2,9 +2,7 @@
 
 namespace App\Controller;
 
-use App\Repository\CashflowCategoryRepository;
-use App\Repository\CashflowTransactionRepository;
-use App\Repository\ProjectRepository;
+use App\Service\CashflowReportService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -13,96 +11,12 @@ use Symfony\Component\Routing\Attribute\Route;
 class CashflowReportController extends AbstractController
 {
     #[Route('/finance/cashflow/report', name: 'cashflow_report')]
-    public function index(
-        Request $request,
-        CashflowTransactionRepository $repository,
-        CashflowCategoryRepository $categoryRepository,
-        ProjectRepository $projectRepository,
-    ): Response {
+    public function index(Request $request, CashflowReportService $service): Response
+    {
         $company = $this->getUser()->getCompanies()[0];
         $projectId = $request->query->get('project');
-        $transactions = $repository->listByCompanyId($company->getId(), $projectId ?: null);
+        $data = $service->build($company, $projectId ?: null);
+        return $this->render('finance/cashflow/report_grouped.html.twig', $data);
 
-        $months = [];
-        $report = [];
-        $balances = [];
-
-        // стартовый баланс по всем счетам
-        $startBalance = 0;
-        foreach ($company->getCashAccounts() as $account) {
-            $startBalance += $account->getOpeningBalance();
-        }
-
-        $addToReport = function (&$node, array $path, string $month, float $amount) use (&$addToReport) {
-            $name = array_shift($path);
-            if (!isset($node[$name])) {
-                $node[$name] = ['__total' => [], '__children' => []];
-            }
-            $node[$name]['__total'][$month] = ($node[$name]['__total'][$month] ?? 0) + $amount;
-            if ($path) {
-                $addToReport($node[$name]['__children'], $path, $month, $amount);
-            }
-        };
-
-        foreach ($transactions as $txn) {
-            $month = $txn->getDate()->format('Y-m');
-            $months[$month] = true;
-
-            $category = $txn->getCategory();
-            $path = [];
-            $cur = $category;
-            while ($cur !== null && count($path) < 4) {
-                array_unshift($path, $cur->getName());
-                $cur = $cur->getParent();
-            }
-
-            $amount = $txn->getAmount();
-            $direction = $txn->getDirection();
-            $signed = $direction === 'expense' ? -$amount : $amount;
-
-            $addToReport($report, $path, $month, $signed);
-
-            $balances[$month][$direction] = ($balances[$month][$direction] ?? 0) + $amount;
-        }
-
-        ksort($months);
-
-        // список месяцев как отсортированный массив
-        $monthKeys = array_keys($months);
-
-        // расчёт остатков
-        $monthly = [];
-        $runningBalance = $startBalance;
-        foreach ($monthKeys as $month) {
-            $income = $balances[$month]['income'] ?? 0;
-            $expense = $balances[$month]['expense'] ?? 0;
-            $monthly[$month]['start'] = $runningBalance;
-            $runningBalance += $income - $expense;
-            $monthly[$month]['end'] = $runningBalance;
-        }
-
-        // получаем корневые категории с сортировкой
-        $rootCategories = $categoryRepository->findBy([
-            'company' => $company,
-            'parent' => null,
-        ], [
-            'sortOrder' => 'ASC',
-        ]);
-
-        $projects = $projectRepository->listByCompanyId($company->getId());
-
-
-
-
-
-
-        return $this->render('finance/cashflow/report_grouped.html.twig', [
-            'report' => $report,
-            'monthly' => $monthly,
-            'months' => $monthKeys,
-            'rootCategories' => $rootCategories,
-            'projects' => $projects,
-            'selectedProject' => $projectId,
-        ]);
     }
 }

--- a/site/src/Service/CashflowReportService.php
+++ b/site/src/Service/CashflowReportService.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Company;
+use App\Repository\CashflowCategoryRepository;
+use App\Repository\CashflowTransactionRepository;
+use App\Repository\ProjectRepository;
+
+class CashflowReportService
+{
+    private CashflowTransactionRepository $transactionRepository;
+    private CashflowCategoryRepository $categoryRepository;
+    private ProjectRepository $projectRepository;
+
+    public function __construct(
+        CashflowTransactionRepository $transactionRepository,
+        CashflowCategoryRepository $categoryRepository,
+        ProjectRepository $projectRepository,
+    ) {
+        $this->transactionRepository = $transactionRepository;
+        $this->categoryRepository = $categoryRepository;
+        $this->projectRepository = $projectRepository;
+    }
+
+    public function build(Company $company, ?string $projectId = null): array
+    {
+        $transactions = $this->transactionRepository->listByCompanyId($company->getId(), $projectId);
+
+        $months = [];
+        $report = [];
+        $balances = [];
+
+        $startBalance = 0;
+        foreach ($company->getCashAccounts() as $account) {
+            $startBalance += $account->getOpeningBalance();
+        }
+
+        $addToReport = function (&$node, array $path, string $month, float $amount) use (&$addToReport) {
+            $name = array_shift($path);
+            if (!isset($node[$name])) {
+                $node[$name] = ['__total' => [], '__children' => []];
+            }
+            $node[$name]['__total'][$month] = ($node[$name]['__total'][$month] ?? 0) + $amount;
+            if ($path) {
+                $addToReport($node[$name]['__children'], $path, $month, $amount);
+            }
+        };
+
+        foreach ($transactions as $txn) {
+            $month = $txn->getDate()->format('Y-m');
+            $months[$month] = true;
+
+            $category = $txn->getCategory();
+            $path = [];
+            $cur = $category;
+            while ($cur !== null && count($path) < 4) {
+                array_unshift($path, $cur->getName());
+                $cur = $cur->getParent();
+            }
+
+            $amount = $txn->getAmount();
+            $direction = $txn->getDirection();
+            $signed = $direction === 'expense' ? -$amount : $amount;
+
+            $addToReport($report, $path, $month, $signed);
+
+            $balances[$month][$direction] = ($balances[$month][$direction] ?? 0) + $amount;
+        }
+
+        ksort($months);
+        $monthKeys = array_keys($months);
+
+        $monthly = [];
+        $runningBalance = $startBalance;
+        foreach ($monthKeys as $month) {
+            $income = $balances[$month]['income'] ?? 0;
+            $expense = $balances[$month]['expense'] ?? 0;
+            $monthly[$month]['start'] = $runningBalance;
+            $runningBalance += $income - $expense;
+            $monthly[$month]['end'] = $runningBalance;
+        }
+
+        $rootCategories = $this->categoryRepository->findBy([
+            'company' => $company,
+            'parent' => null,
+        ], [
+            'sortOrder' => 'ASC',
+        ]);
+
+        $projects = $this->projectRepository->listByCompanyId($company->getId());
+
+        return [
+            'report' => $report,
+            'monthly' => $monthly,
+            'months' => $monthKeys,
+            'rootCategories' => $rootCategories,
+            'projects' => $projects,
+            'selectedProject' => $projectId,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- extract cash flow report generation logic into a service
- use new service in HTML controller
- add API controller returning report as JSON

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ab3466ae88323a763bd7d8082363a