### PR TITLE
Add date filters for cashflow report

### DIFF
--- a/site/src/Controller/Api/CashflowReportController.php
+++ b/site/src/Controller/Api/CashflowReportController.php
@@ -15,8 +15,15 @@ class CashflowReportController extends AbstractController
     {
         $company = $this->getUser()->getCompanies()[0];
         $projectId = $request->query->get('project');
+        $dateFrom = $request->query->get('dateFrom');
+        $dateTo = $request->query->get('dateTo');
 
-        $data = $service->build($company, $projectId ?: null);
+        $data = $service->build(
+            $company,
+            $projectId ?: null,
+            $dateFrom ? new \DateTimeImmutable($dateFrom) : null,
+            $dateTo ? new \DateTimeImmutable($dateTo) : null,
+        );
 
         // convert entities to simple arrays for JSON response
         $data['rootCategories'] = array_map(static fn($c) => [

--- a/site/src/Controller/CashflowReportController.php
+++ b/site/src/Controller/CashflowReportController.php
@@ -15,7 +15,15 @@ class CashflowReportController extends AbstractController
     {
         $company = $this->getUser()->getCompanies()[0];
         $projectId = $request->query->get('project');
-        $data = $service->build($company, $projectId ?: null);
+        $dateFrom = $request->query->get('dateFrom');
+        $dateTo = $request->query->get('dateTo');
+
+        $data = $service->build(
+            $company,
+            $projectId ?: null,
+            $dateFrom ? new \DateTimeImmutable($dateFrom) : null,
+            $dateTo ? new \DateTimeImmutable($dateTo) : null,
+        );
         return $this->render('finance/cashflow/report_grouped.html.twig', $data);
 
     }

--- a/site/src/Repository/CashflowTransactionRepository.php
+++ b/site/src/Repository/CashflowTransactionRepository.php
@@ -21,7 +21,7 @@ class CashflowTransactionRepository
         $this->repo = $em->getRepository(CashflowTransaction::class);
     }
 
-    public function listByCompanyId(string $id, ?string $projectId = null): array
+    public function listByCompanyId(string $id, ?string $projectId = null, ?\DateTimeImmutable $dateFrom = null, ?\DateTimeImmutable $dateTo = null): array
     {
         Assert::uuid($id);
 
@@ -33,6 +33,16 @@ class CashflowTransactionRepository
             Assert::uuid($projectId);
             $qb->andWhere('t.project = :project')
                 ->setParameter('project', $projectId);
+        }
+
+        if ($dateFrom !== null) {
+            $qb->andWhere('t.date >= :dateFrom')
+                ->setParameter('dateFrom', $dateFrom);
+        }
+
+        if ($dateTo !== null) {
+            $qb->andWhere('t.date <= :dateTo')
+                ->setParameter('dateTo', $dateTo);
         }
 
         return $qb->getQuery()->getResult();

--- a/site/src/Service/CashflowReportService.php
+++ b/site/src/Service/CashflowReportService.php
@@ -23,9 +23,19 @@ class CashflowReportService
         $this->projectRepository = $projectRepository;
     }
 
-    public function build(Company $company, ?string $projectId = null): array
+    public function build(
+        Company $company,
+        ?string $projectId = null,
+        ?\DateTimeImmutable $dateFrom = null,
+        ?\DateTimeImmutable $dateTo = null,
+    ): array
     {
-        $transactions = $this->transactionRepository->listByCompanyId($company->getId(), $projectId);
+        $transactions = $this->transactionRepository->listByCompanyId(
+            $company->getId(),
+            $projectId,
+            $dateFrom,
+            $dateTo,
+        );
 
         $months = [];
         $report = [];
@@ -97,6 +107,8 @@ class CashflowReportService
             'rootCategories' => $rootCategories,
             'projects' => $projects,
             'selectedProject' => $projectId,
+            'dateFrom' => $dateFrom,
+            'dateTo' => $dateTo,
         ];
     }
 }

--- a/site/templates/finance/cashflow/report_grouped.html.twig
+++ b/site/templates/finance/cashflow/report_grouped.html.twig
@@ -33,6 +33,12 @@
                     {% endfor %}
                 </select>
             </div>
+            <div class="col-auto">
+                <input type="date" name="dateFrom" value="{{ dateFrom ? dateFrom|date('Y-m-d') }}" class="form-control" onchange="this.form.submit()">
+            </div>
+            <div class="col-auto">
+                <input type="date" name="dateTo" value="{{ dateTo ? dateTo|date('Y-m-d') }}" class="form-control" onchange="this.form.submit()">
+            </div>
         </form>
 
         <div class="table-responsive">


### PR DESCRIPTION
## Summary
- enable filtering cashflow report by date range
- support `dateFrom` and `dateTo` parameters in API
- show date fields on cashflow report page

## Testing
- `php bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684adbd0d86c8323b1f645dc0100a159