### PR TITLE
Add controller for editing Company

### DIFF
--- a/site/src/Controller/CompanyController.php
+++ b/site/src/Controller/CompanyController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\Company;
+use App\Form\CompanyType;
+use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/company')]
+class CompanyController extends AbstractController
+{
+    #[Route('/', name: 'company_index')]
+    public function index(): Response
+    {
+        $companies = $this->getUser()->getCompanies();
+
+        return $this->render('company/index.html.twig', [
+            'companies' => $companies,
+        ]);
+    }
+
+    #[Route('/new', name: 'company_new')]
+    public function new(Request $request, EntityManagerInterface $em): Response
+    {
+        $company = new Company(
+            Uuid::uuid4()->toString(),
+            '',
+            $this->getUser(),
+            new \DateTimeImmutable()
+        );
+
+        $form = $this->createForm(CompanyType::class, $company);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $em->persist($company);
+            $em->flush();
+
+            return $this->redirectToRoute('company_index');
+        }
+
+        return $this->render('company/new.html.twig', [
+            'form' => $form->createView(),
+        ]);
+    }
+
+    #[Route('/{id}/edit', name: 'company_edit')]
+    public function edit(Company $company, Request $request, EntityManagerInterface $em): Response
+    {
+        $form = $this->createForm(CompanyType::class, $company);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $em->flush();
+
+            return $this->redirectToRoute('company_index');
+        }
+
+        return $this->render('company/edit.html.twig', [
+            'form' => $form->createView(),
+            'company' => $company,
+        ]);
+    }
+
+    #[Route('/{id}/delete', name: 'company_delete')]
+    public function delete(Company $company, EntityManagerInterface $em): Response
+    {
+        $em->remove($company);
+        $em->flush();
+
+        return $this->redirectToRoute('company_index');
+    }
+}

--- a/site/src/Entity/Company.php
+++ b/site/src/Entity/Company.php
@@ -66,6 +66,13 @@ class Company
         return $this->name;
     }
 
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
     public function getOwner(): User
     {
         return $this->owner;

--- a/site/src/Form/CompanyType.php
+++ b/site/src/Form/CompanyType.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\Company;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class CompanyType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder->add('name', TextType::class, [
+            'label' => 'Название компании',
+        ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => Company::class,
+        ]);
+    }
+}

--- a/site/templates/base.html.twig
+++ b/site/templates/base.html.twig
@@ -59,6 +59,9 @@
                                 <a class="dropdown-item" href="{{ path('cash_account_index') }}">
                                     Счета и Кассы
                                 </a>
+                                <a class="dropdown-item" href="{{ path('company_index') }}">
+                                    Компании
+                                </a>
                                 <a class="dropdown-item" href="{{ path('project_index') }}">
                                     Проекты
                                 </a>

--- a/site/templates/company/edit.html.twig
+++ b/site/templates/company/edit.html.twig
@@ -1,0 +1,10 @@
+{% extends 'base.html.twig' %}
+{% block body %}
+    <div class="container-xl">
+        <h2>{{ app.request.get('_route') ends with 'new' ? 'Создать компанию' : 'Редактировать компанию' }}</h2>
+        {{ form_start(form) }}
+        {{ form_row(form.name) }}
+        <button class="btn btn-success">Сохранить</button>
+        {{ form_end(form) }}
+    </div>
+{% endblock %}

--- a/site/templates/company/index.html.twig
+++ b/site/templates/company/index.html.twig
@@ -1,0 +1,32 @@
+{% extends 'base.html.twig' %}
+{% block title %}Компании{% endblock %}
+
+{% block body %}
+    <div class="container mt-4">
+        <h2>Компании</h2>
+        <a href="{{ path('company_new') }}" class="btn btn-primary mb-3">Добавить компанию</a>
+
+        <table class="table table-striped">
+            <thead>
+            <tr>
+                <th>Название</th>
+                <th>Дата создания</th>
+                <th></th>
+            </tr>
+            </thead>
+            <tbody>
+            {% for company in companies %}
+                <tr>
+                    <td>{{ company.name }}</td>
+                    <td>{{ company.createdAt|date('Y-m-d H:i') }}</td>
+                    <td>
+                        <a href="{{ path('company_edit', {id: company.id}) }}" class="btn btn-sm btn-warning">Редактировать</a>
+                    </td>
+                </tr>
+            {% else %}
+                <tr><td colspan="3">Нет компаний</td></tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+{% endblock %}

--- a/site/templates/company/new.html.twig
+++ b/site/templates/company/new.html.twig
@@ -1,0 +1,10 @@
+{% extends 'base.html.twig' %}
+{% block body %}
+    <div class="container-xl">
+        <h2>{{ app.request.get('_route') ends with 'new' ? 'Создать компанию' : 'Редактировать компанию' }}</h2>
+        {{ form_start(form) }}
+        {{ form_row(form.name) }}
+        <button class="btn btn-success">Сохранить</button>
+        {{ form_end(form) }}
+    </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- allow editing Company name via `setName`
- add Company form and CRUD controller
- create Company templates for listing, editing
- expose link in navigation

## Testing
- `php bin/phpunit` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684ae01f15a48323b0eeb514efc0e113