### PR TITLE
Add administration menu with companies page

### DIFF
--- a/site/src/Controller/CompanyController.php
+++ b/site/src/Controller/CompanyController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\Company;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/company')]
+class CompanyController extends AbstractController
+{
+    #[Route('/', name: 'company_index')]
+    public function index(): Response
+    {
+        $user = $this->getUser();
+        $companies = $user ? $user->getCompanies() : [];
+
+        return $this->render('company/index.html.twig', [
+            'companies' => $companies,
+        ]);
+    }
+
+    #[Route('/{id}/edit', name: 'company_edit')]
+    public function edit(Company $company): Response
+    {
+        return $this->render('company/edit.html.twig', [
+            'company' => $company,
+        ]);
+    }
+}

--- a/site/templates/base.html.twig
+++ b/site/templates/base.html.twig
@@ -65,6 +65,19 @@
                             </div>
                         </li>
 
+                        <li class="nav-item dropdown">
+                            <a class="nav-link dropdown-toggle" href="#navbar-admin" data-bs-toggle="dropdown" data-bs-auto-close="outside" role="button" aria-expanded="false" >
+                                <span class="nav-link-title">
+                                      Администрирование
+                                </span>
+                            </a>
+                            <div class="dropdown-menu">
+                                <a class="dropdown-item" href="{{ path('company_index') }}">
+                                    Компании
+                                </a>
+                            </div>
+                        </li>
+
                     </ul>
                 </div>
             </div>

--- a/site/templates/company/edit.html.twig
+++ b/site/templates/company/edit.html.twig
@@ -1,0 +1,9 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Редактирование компании{% endblock %}
+
+{% block body %}
+    <div class="container mt-4">
+        <h2>{{ company.name }}</h2>
+    </div>
+{% endblock %}

--- a/site/templates/company/index.html.twig
+++ b/site/templates/company/index.html.twig
@@ -1,0 +1,27 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Компании{% endblock %}
+
+{% block body %}
+    <div class="container mt-4">
+        <h2>Компании</h2>
+        <table class="table table-striped">
+            <thead>
+            <tr>
+                <th>Название</th>
+            </tr>
+            </thead>
+            <tbody>
+            {% for company in companies %}
+                <tr>
+                    <td>
+                        <a href="{{ path('company_edit', {id: company.id}) }}">{{ company.name }}</a>
+                    </td>
+                </tr>
+            {% else %}
+                <tr><td colspan="1">Нет компаний</td></tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `CompanyController` with placeholder routes
- create index and edit templates for companies
- extend base template to include new "Администрирование" dropdown with link to companies page

## Testing
- `make site-test` *(fails: docker not available)*

------
https://chatgpt.com/codex/tasks/task_e_684ae285c6d88323b267944584bff59d