### PR TITLE
Fix cashflow report date filter

### DIFF
--- a/site/src/Controller/CashflowReportController.php
+++ b/site/src/Controller/CashflowReportController.php
@@ -18,11 +18,16 @@ class CashflowReportController extends AbstractController
         $dateFrom = $request->query->get('dateFrom');
         $dateTo = $request->query->get('dateTo');
 
+        $dateToDt = null;
+        if ($dateTo) {
+            $dateToDt = (new \DateTimeImmutable($dateTo))->setTime(23, 59, 59);
+        }
+
         $data = $service->build(
             $company,
             $projectId ?: null,
             $dateFrom ? new \DateTimeImmutable($dateFrom) : null,
-            $dateTo ? new \DateTimeImmutable($dateTo) : null,
+            $dateToDt,
         );
         return $this->render('finance/cashflow/report_grouped.html.twig', $data);
 


### PR DESCRIPTION
## Summary
- ensure `dateTo` includes the whole day when filtering cashflow reports

## Testing
- `phpunit` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684af01269cc8323aa797c33b66f0f45