### PR TITLE
Fix CI config and cleanup gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,13 @@
-<<<<<<< HEAD
-# These are some examples of commonly ignored file patterns.
-# You should customize this list as applicable to your project.
-# Learn more about .gitignore:
-#     https://www.atlassian.com/git/tutorials/saving-changes/gitignore
-
 # Node artifact files
 node_modules/
 dist/
+
+# Custom directories
 /xxx
+/xxx-pass
+/storage/docker/elasticsearch/
+/shopingo/
+
 # Compiled Java class files
 *.class
 
@@ -47,10 +47,3 @@ Thumbs.db
 *.flv
 *.mov
 *.wmv
-
-=======
-###> symfony/framework-bundle ###
->>>>>>> Start
-/xxx-pass
-/storage/docker/elasticsearch/
-/shopingo/

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -86,4 +86,3 @@ networks:
     traefik-public:
         name: traefik-public
         driver: bridge
-    default:


### PR DESCRIPTION
## Summary
- remove leftover `default:` line in `docker-compose-production.yml`
- clean up merge conflict markers in `.gitignore`

## Testing
- `docker compose -f docker-compose-production.yml config` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684d41579b2c8323a169e2601b8a79a3