### PR TITLE
Fix missing root route

### DIFF
--- a/site/src/Controller/HomeController.php
+++ b/site/src/Controller/HomeController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class HomeController extends AbstractController
+{
+    #[Route('/', name: 'app_home')]
+    public function index(): Response
+    {
+        return $this->redirectToRoute('app_dashboard');
+    }
+}


### PR DESCRIPTION
## Summary
- add a HomeController to redirect `/` to the dashboard

## Testing
- `make site-test` *(fails: docker not available)*

------
https://chatgpt.com/codex/tasks/task_e_684d431e1d448323927e1a6bd2b7664e